### PR TITLE
Fix nullable MatchReport retrieval

### DIFF
--- a/Repositories/Interfaces/IMatchReportRepository.cs
+++ b/Repositories/Interfaces/IMatchReportRepository.cs
@@ -7,7 +7,7 @@ namespace MatchReportNamespace.Repositories
     public interface IMatchReportRepository
     {
         Task<IEnumerable<MatchReport>> GetAllAsync();
-        Task<MatchReport> GetByIdAsync(Guid id);
+        Task<MatchReport?> GetByIdAsync(Guid id);
         Task AddAsync(MatchReport report);
         Task UpdateAsync(MatchReport report);
         Task DeleteAsync(Guid id);

--- a/Services/Interfaces/IMatchReportService.cs
+++ b/Services/Interfaces/IMatchReportService.cs
@@ -6,7 +6,7 @@ namespace MatchReportNamespace.Services
     public interface IMatchReportService
     {
         Task<IEnumerable<MatchReport>> GetAllAsync();
-        Task<MatchReport> GetByIdAsync(Guid id);
+        Task<MatchReport?> GetByIdAsync(Guid id);
         Task<MatchReport> CreateAsync(MatchReport report);
         Task UpdateAsync(Guid id, MatchReport report);
         Task DeleteAsync(Guid id);

--- a/Services/MatchReportService.cs
+++ b/Services/MatchReportService.cs
@@ -17,7 +17,7 @@ namespace MatchReportNamespace.Services
         public async Task<IEnumerable<MatchReport>> GetAllAsync() =>
             await _repository.GetAllAsync();
 
-        public async Task<MatchReport> GetByIdAsync(Guid id) =>
+        public async Task<MatchReport?> GetByIdAsync(Guid id) =>
             await _repository.GetByIdAsync(id);
 
         public async Task<MatchReport> CreateAsync(MatchReport report)


### PR DESCRIPTION
## Summary
- fix `GetByIdAsync` signatures to return `MatchReport?`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853de9643208321b6716d3e17eac8b5