### PR TITLE
Fix connection string configuration

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -19,20 +19,20 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
 // Inyección de dependencias
-builder.Services.AddDbContext<AppDbContext>(options =>
-    options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection")));
-
 builder.Services.AddScoped<IMatchReportRepository, MatchReportRepository>();
 builder.Services.AddScoped<IPlayerRepository, PlayerRepository>();
 builder.Services.AddScoped<IMatchReportService, MatchReportService>(); 
 builder.Services.AddScoped<IPlayerService, PlayerService>();
 
+var connectionString = builder.Configuration.GetConnectionString("DefaultConnection")
+                      ?? builder.Configuration.GetConnectionString("DATABASE_URL")
+                      ?? builder.Configuration["DATABASE_URL"]
+                      ?? Environment.GetEnvironmentVariable("DATABASE_URL");
 
-
-var rawUrl = builder.Configuration["ConnectionStrings:DefaultConnection"] ?? 
-             builder.Configuration["ConnectionStrings:DATABASE_URL"];
-
-var connectionString = rawUrl;
+if (string.IsNullOrWhiteSpace(connectionString))
+{
+    throw new InvalidOperationException("Database connection string is not configured.");
+}
 
 builder.Services.AddDbContext<AppDbContext>(options =>
     options.UseNpgsql(connectionString));

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -7,6 +7,7 @@
     },
     "AllowedHosts": "*",
     "ConnectionStrings": {
+        "DefaultConnection": "Host=dpg-d19qb82dbo4c73bod08g-a.frankfurt-postgres.render.com;Port=5432;Database=warapi_db;Username=warapi_db_user;Password=hfApEosrhj4rrrz5xslonSk3XvHeekJa;SSL Mode=Require;Trust Server Certificate=true",
         "DATABASE_URL": "Host=dpg-d19qb82dbo4c73bod08g-a.frankfurt-postgres.render.com;Port=5432;Database=warapi_db;Username=warapi_db_user;Password=hfApEosrhj4rrrz5xslonSk3XvHeekJa;SSL Mode=Require;Trust Server Certificate=true"
     }
 

--- a/appsettings.json
+++ b/appsettings.json
@@ -7,6 +7,7 @@
     },
     "AllowedHosts": "*",
     "ConnectionStrings": {
+        "DefaultConnection": "Host=dpg-d19qb82dbo4c73bod08g-a.frankfurt-postgres.render.com;Port=5432;Database=warapi_db;Username=warapi_db_user;Password=hfApEosrhj4rrrz5xslonSk3XvHeekJa;SSL Mode=Require;Trust Server Certificate=true",
         "DATABASE_URL": "Host=dpg-d19qb82dbo4c73bod08g-a.frankfurt-postgres.render.com;Port=5432;Database=warapi_db;Username=warapi_db_user;Password=hfApEosrhj4rrrz5xslonSk3XvHeekJa;SSL Mode=Require;Trust Server Certificate=true"
     }
 


### PR DESCRIPTION
## Summary
- read DATABASE_URL environment variable
- ensure connection string exists for EF Core
- add DefaultConnection key in appsettings

## Testing
- `dotnet build -v minimal` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6854ff70a4d883218a9536ece7cf0f31