### PR TITLE
Add CORS policy

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -18,6 +18,15 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
+// Configurar CORS para permitir cualquier origen, encabezado y método
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("AllowAll", policy =>
+        policy.AllowAnyOrigin()
+              .AllowAnyHeader()
+              .AllowAnyMethod());
+});
+
 // Inyección de dependencias
 builder.Services.AddScoped<IMatchReportRepository, MatchReportRepository>();
 builder.Services.AddScoped<IPlayerRepository, PlayerRepository>();
@@ -76,6 +85,9 @@ catch (Exception ex)
 
 
 app.UseHttpsRedirection();
+
+// Habilitar la política de CORS definida anteriormente
+app.UseCors("AllowAll");
 
 app.UseAuthorization();
 


### PR DESCRIPTION
## Summary
- allow any origin/method/header in Program.cs
- apply CORS policy in the request pipeline

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857ad6ebb848321a066c2bd6c978025