### PR TITLE
Add player statistics endpoints

### DIFF
--- a/Controllers/PlayerStatsController.cs
+++ b/Controllers/PlayerStatsController.cs
@@ -1,0 +1,61 @@
+using Microsoft.AspNetCore.Mvc;
+using WarApi.Services.Interfaces;
+
+namespace WarApi.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class PlayerStatsController : ControllerBase
+    {
+        private readonly IPlayerStatsService _statsService;
+
+        public PlayerStatsController(IPlayerStatsService statsService)
+        {
+            _statsService = statsService;
+        }
+
+        [HttpGet("{playerId}/total")]
+        public async Task<ActionResult<int>> GetTotal(Guid playerId)
+            => Ok(await _statsService.GetTotalGames(playerId));
+
+        [HttpGet("{playerId}/wins")]
+        public async Task<ActionResult<int>> GetWins(Guid playerId)
+            => Ok(await _statsService.GetWins(playerId));
+
+        [HttpGet("{playerId}/losses")]
+        public async Task<ActionResult<int>> GetLosses(Guid playerId)
+            => Ok(await _statsService.GetLosses(playerId));
+
+        [HttpGet("{playerId}/draws")]
+        public async Task<ActionResult<int>> GetDraws(Guid playerId)
+            => Ok(await _statsService.GetDraws(playerId));
+
+        [HttpGet("{playerId}/army/{army}/total")]
+        public async Task<ActionResult<int>> GetGamesByArmy(Guid playerId, string army)
+            => Ok(await _statsService.GetGamesByArmy(playerId, army));
+
+        [HttpGet("{playerId}/army/{army}/wins")]
+        public async Task<ActionResult<int>> GetWinsByArmy(Guid playerId, string army)
+            => Ok(await _statsService.GetWinsByArmy(playerId, army));
+
+        [HttpGet("{playerId}/map/{map}/winrate")]
+        public async Task<ActionResult<double>> GetMapWinRate(Guid playerId, string map)
+            => Ok(await _statsService.GetWinRateOnMap(playerId, map));
+
+        [HttpGet("{playerId}/deployment/{deployment}/winrate")]
+        public async Task<ActionResult<double>> GetDeploymentWinRate(Guid playerId, string deployment)
+            => Ok(await _statsService.GetWinRateByDeployment(playerId, deployment));
+
+        [HttpGet("{playerId}/primary/{mission}/winrate")]
+        public async Task<ActionResult<double>> GetPrimaryWinRate(Guid playerId, string mission)
+            => Ok(await _statsService.GetWinRateByPrimary(playerId, mission));
+
+        [HttpGet("{playerId}/best-opponent")]
+        public async Task<ActionResult<string?>> GetBestOpponent(Guid playerId)
+            => Ok(await _statsService.GetBestOpponentFaction(playerId));
+
+        [HttpGet("{playerId}/worst-opponent")]
+        public async Task<ActionResult<string?>> GetWorstOpponent(Guid playerId)
+            => Ok(await _statsService.GetWorstOpponentFaction(playerId));
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -30,8 +30,9 @@ builder.Services.AddCors(options =>
 // Inyección de dependencias
 builder.Services.AddScoped<IMatchReportRepository, MatchReportRepository>();
 builder.Services.AddScoped<IPlayerRepository, PlayerRepository>();
-builder.Services.AddScoped<IMatchReportService, MatchReportService>(); 
+builder.Services.AddScoped<IMatchReportService, MatchReportService>();
 builder.Services.AddScoped<IPlayerService, PlayerService>();
+builder.Services.AddScoped<IPlayerStatsService, PlayerStatsService>();
 
 var connectionString = builder.Configuration.GetConnectionString("DefaultConnection")
                       ?? builder.Configuration.GetConnectionString("DATABASE_URL")

--- a/Services/Interfaces/IPlayerStatsService.cs
+++ b/Services/Interfaces/IPlayerStatsService.cs
@@ -1,0 +1,19 @@
+using MatchReportNamespace;
+
+namespace WarApi.Services.Interfaces
+{
+    public interface IPlayerStatsService
+    {
+        Task<int> GetTotalGames(Guid playerId);
+        Task<int> GetWins(Guid playerId);
+        Task<int> GetLosses(Guid playerId);
+        Task<int> GetDraws(Guid playerId);
+        Task<int> GetGamesByArmy(Guid playerId, string army);
+        Task<int> GetWinsByArmy(Guid playerId, string army);
+        Task<double> GetWinRateOnMap(Guid playerId, string map);
+        Task<double> GetWinRateByDeployment(Guid playerId, string deployment);
+        Task<double> GetWinRateByPrimary(Guid playerId, string primary);
+        Task<string?> GetBestOpponentFaction(Guid playerId);
+        Task<string?> GetWorstOpponentFaction(Guid playerId);
+    }
+}

--- a/Services/PlayerStatsService.cs
+++ b/Services/PlayerStatsService.cs
@@ -1,0 +1,150 @@
+using MatchReportNamespace;
+using MatchReportNamespace.Services;
+using WarApi.Services.Interfaces;
+
+namespace WarApi.Services
+{
+    public class PlayerStatsService : IPlayerStatsService
+    {
+        private readonly IMatchReportService _matchReportService;
+
+        public PlayerStatsService(IMatchReportService matchReportService)
+        {
+            _matchReportService = matchReportService;
+        }
+
+        private async Task<List<MatchReport>> GetReports(Guid playerId)
+        {
+            return await _matchReportService.GetReportsByUser(playerId);
+        }
+
+        private static bool IsDraw(MatchReport report)
+        {
+            return report.FinalScoreA == report.FinalScoreB;
+        }
+
+        private static bool DidPlayerWin(MatchReport report, Guid playerId)
+        {
+            if (IsDraw(report)) return false;
+
+            bool isA = report.PlayerAId == playerId;
+            return isA ? report.FinalScoreA > report.FinalScoreB
+                        : report.FinalScoreB > report.FinalScoreA;
+        }
+
+        private static bool DidPlayerLose(MatchReport report, Guid playerId)
+        {
+            if (IsDraw(report)) return false;
+            return !DidPlayerWin(report, playerId);
+        }
+
+        private static bool PlayerUsedArmy(MatchReport report, Guid playerId, string army)
+        {
+            return (report.PlayerAId == playerId && string.Equals(report.ListA, army, StringComparison.OrdinalIgnoreCase)) ||
+                   (report.PlayerBId == playerId && string.Equals(report.ListB, army, StringComparison.OrdinalIgnoreCase));
+        }
+
+        public async Task<int> GetTotalGames(Guid playerId)
+        {
+            var reports = await GetReports(playerId);
+            return reports.Count;
+        }
+
+        public async Task<int> GetWins(Guid playerId)
+        {
+            var reports = await GetReports(playerId);
+            return reports.Count(r => DidPlayerWin(r, playerId));
+        }
+
+        public async Task<int> GetLosses(Guid playerId)
+        {
+            var reports = await GetReports(playerId);
+            return reports.Count(r => DidPlayerLose(r, playerId));
+        }
+
+        public async Task<int> GetDraws(Guid playerId)
+        {
+            var reports = await GetReports(playerId);
+            return reports.Count(IsDraw);
+        }
+
+        public async Task<int> GetGamesByArmy(Guid playerId, string army)
+        {
+            var reports = await GetReports(playerId);
+            return reports.Count(r => PlayerUsedArmy(r, playerId, army));
+        }
+
+        public async Task<int> GetWinsByArmy(Guid playerId, string army)
+        {
+            var reports = await GetReports(playerId);
+            return reports.Where(r => PlayerUsedArmy(r, playerId, army))
+                          .Count(r => DidPlayerWin(r, playerId));
+        }
+
+        private static double CalculateWinRate(int wins, int games)
+        {
+            return games == 0 ? 0 : (double)wins / games * 100.0;
+        }
+
+        public async Task<double> GetWinRateOnMap(Guid playerId, string map)
+        {
+            var reports = (await GetReports(playerId)).Where(r => string.Equals(r.Map, map, StringComparison.OrdinalIgnoreCase)).ToList();
+            int wins = reports.Count(r => DidPlayerWin(r, playerId));
+            return CalculateWinRate(wins, reports.Count);
+        }
+
+        public async Task<double> GetWinRateByDeployment(Guid playerId, string deployment)
+        {
+            var reports = (await GetReports(playerId)).Where(r => string.Equals(r.Deployment, deployment, StringComparison.OrdinalIgnoreCase)).ToList();
+            int wins = reports.Count(r => DidPlayerWin(r, playerId));
+            return CalculateWinRate(wins, reports.Count);
+        }
+
+        public async Task<double> GetWinRateByPrimary(Guid playerId, string primary)
+        {
+            var reports = (await GetReports(playerId)).Where(r => string.Equals(r.PrimaryMission, primary, StringComparison.OrdinalIgnoreCase)).ToList();
+            int wins = reports.Count(r => DidPlayerWin(r, playerId));
+            return CalculateWinRate(wins, reports.Count);
+        }
+
+        public async Task<string?> GetBestOpponentFaction(Guid playerId)
+        {
+            var reports = await GetReports(playerId);
+            var stats = new Dictionary<string, (int Wins, int Games)>();
+
+            foreach (var r in reports)
+            {
+                string faction = r.PlayerAId == playerId ? r.ListB : r.ListA;
+                if (!stats.ContainsKey(faction)) stats[faction] = (0, 0);
+                var val = stats[faction];
+                if (DidPlayerWin(r, playerId)) val.Wins++;
+                val.Games++;
+                stats[faction] = val;
+            }
+
+            if (stats.Count == 0) return null;
+
+            return stats.OrderByDescending(kv => CalculateWinRate(kv.Value.Wins, kv.Value.Games)).First().Key;
+        }
+
+        public async Task<string?> GetWorstOpponentFaction(Guid playerId)
+        {
+            var reports = await GetReports(playerId);
+            var stats = new Dictionary<string, (int Wins, int Games)>();
+
+            foreach (var r in reports)
+            {
+                string faction = r.PlayerAId == playerId ? r.ListB : r.ListA;
+                if (!stats.ContainsKey(faction)) stats[faction] = (0, 0);
+                var val = stats[faction];
+                if (DidPlayerWin(r, playerId)) val.Wins++;
+                val.Games++;
+                stats[faction] = val;
+            }
+
+            if (stats.Count == 0) return null;
+
+            return stats.OrderBy(kv => CalculateWinRate(kv.Value.Wins, kv.Value.Games)).First().Key;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `PlayerStatsService` and interface to aggregate stats per player
- expose new `PlayerStatsController` with endpoints for game counts and win rates
- register service in dependency injection

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685b91d1adc88321b8ea21b2b5419492