### PR TITLE
Allow zero limit for ideal scenario

### DIFF
--- a/Services/PlayerStatsService.cs
+++ b/Services/PlayerStatsService.cs
@@ -176,7 +176,8 @@ private static void Accumulate(Dictionary<string, (int Wins, int Games)> dict, s
                 Accumulate(secondaries, sec, win);
             }
 
-            int limit = Math.Clamp(top, 1, 12);
+            // Allow 0 to return empty lists while still capping the result size
+            int limit = Math.Clamp(top, 0, 12);
 
             PlayerIdealScenarioDto result = new()
             {


### PR DESCRIPTION
## Summary
- let callers request zero results in `GetIdealScenario`
- document the new lower bound in code

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b9b9803508321a0ec9a396133bc73