### PR TITLE
Remove unused MatchReportNamespace import

### DIFF
--- a/Services/Interfaces/IPlayerStatsService.cs
+++ b/Services/Interfaces/IPlayerStatsService.cs
@@ -1,4 +1,3 @@
-using MatchReportNamespace;
 using WarApi.Dtos;
 
 


### PR DESCRIPTION
## Summary
- clean up `IPlayerStatsService` by dropping an unused using statement

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b9b9c80e88321834398f86bcf0ea1