### PR TITLE
Stop backend score calculation

### DIFF
--- a/Controllers/MatchReportController.cs
+++ b/Controllers/MatchReportController.cs
@@ -99,10 +99,10 @@ namespace MatchReportNamespace.Controllers
                 KillsB = dto.KillsB,
                 PrimaryResult = Enum.TryParse<PrimaryWinner>(dto.PrimaryResult, out var result) ? result : PrimaryWinner.None,
                 SecondaryWinA = dto.SecondaryWinA,
-                SecondaryWinB = dto.SecondaryWinB
+                SecondaryWinB = dto.SecondaryWinB,
+                FinalScoreA = dto.FinalScoreA,
+                FinalScoreB = dto.FinalScoreB
             };
-
-            report.CalculateFinalScore();
 
             await _service.CreateAsync(report);
 

--- a/Models/DTO/MatchReportCreateDto.cs
+++ b/Models/DTO/MatchReportCreateDto.cs
@@ -34,5 +34,8 @@ namespace WarApi.Dtos
         public string PrimaryResult { get; set; } = "None"; // Puede ser PlayerA, PlayerB, Both, None
         public bool SecondaryWinA { get; set; }
         public bool SecondaryWinB { get; set; }
+
+        public int FinalScoreA { get; set; }
+        public int FinalScoreB { get; set; }
     }
 }

--- a/Models/MatchReport.cs
+++ b/Models/MatchReport.cs
@@ -61,46 +61,5 @@ namespace MatchReportNamespace
             Date = DateTime.Now;
         }
 
-        public void CalculateFinalScore()
-        {
-            int pointDiff = KillsA - KillsB;
-            double percentage = (double)Math.Abs(pointDiff) / 4000.0;
-
-            // Scale to 0–16
-            int basePoints = (int)Math.Round(percentage * 16);
-            if (basePoints > 16) basePoints = 16;
-
-            int pointsA = pointDiff > 0 ? basePoints : 16 - basePoints;
-            int pointsB = 16 - pointsA;
-
-            // Add mission bonuses
-            if (PrimaryResult == PrimaryWinner.PlayerA) pointsA += 3;
-            else if (PrimaryResult == PrimaryWinner.PlayerB) pointsB += 3;
-            else if (PrimaryResult == PrimaryWinner.Both)
-            {
-                pointsA += 3;
-                pointsB += 3;
-            }
-
-            if (SecondaryWinA) pointsA += 1;
-            if (SecondaryWinB) pointsB += 1;
-
-            // Clamp to 0–20
-            pointsA = Math.Clamp(pointsA, 0, 20);
-            pointsB = Math.Clamp(pointsB, 0, 20);
-
-            // Ensure total is 20
-            if (pointsA + pointsB > 20)
-            {
-                int excess = (pointsA + pointsB) - 20;
-                if (pointsA > pointsB)
-                    pointsA -= excess;
-                else
-                    pointsB -= excess;
-            }
-            this.FinalScoreA = pointsA;
-            this.FinalScoreB = pointsB;
-
-        }
     }
 }

--- a/Services/MatchReportService.cs
+++ b/Services/MatchReportService.cs
@@ -23,7 +23,6 @@ namespace MatchReportNamespace.Services
         public async Task<MatchReport> CreateAsync(MatchReport report)
         {
             report.Id = Guid.NewGuid();
-            report.CalculateFinalScore();
             await _repository.AddAsync(report);
             return report;
         }
@@ -41,7 +40,6 @@ namespace MatchReportNamespace.Services
             if (existing == null) return;
 
             updatedReport.Id = id;
-            updatedReport.CalculateFinalScore();
             await _repository.UpdateAsync(updatedReport);
         }
 


### PR DESCRIPTION
## Summary
- remove server-side `CalculateFinalScore` method
- accept final score from `MatchReportCreateDto`
- save given scores instead of computing them

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bfac962308321990cd12dd36a5887