### PR TITLE
Fix player retrieval in reports

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -11,8 +11,11 @@ using WarApi.Services.Interfaces;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Agregar controladores
-builder.Services.AddControllers();
+// Agregar controladores con manejo para referencias cíclicas
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+        options.JsonSerializerOptions.ReferenceHandler =
+            System.Text.Json.Serialization.ReferenceHandler.IgnoreCycles);
 
 // Agregar Swagger
 builder.Services.AddEndpointsApiExplorer();

--- a/Repositories/MatchReportRepository.cs
+++ b/Repositories/MatchReportRepository.cs
@@ -14,12 +14,18 @@ namespace MatchReportNamespace.Repositories
 
         public async Task<IEnumerable<MatchReport>> GetAllAsync()
         {
-            return await _context.MatchReports.ToListAsync();
+            return await _context.MatchReports
+                                 .Include(m => m.PlayerA)
+                                 .Include(m => m.PlayerB)
+                                 .ToListAsync();
         }
 
         public async Task<MatchReport?> GetByIdAsync(Guid id)
         {
-            return await _context.MatchReports.FindAsync(id);
+            return await _context.MatchReports
+                                 .Include(m => m.PlayerA)
+                                 .Include(m => m.PlayerB)
+                                 .FirstOrDefaultAsync(m => m.Id == id);
         }
 
         public async Task AddAsync(MatchReport report)


### PR DESCRIPTION
## Summary
- include PlayerA and PlayerB when fetching match reports
- prevent possible circular references in JSON output

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bfed4a3d8832196009c617ce73b5c