### PR TITLE
Prevent password exposure in Player responses

### DIFF
--- a/Models/Player.cs
+++ b/Models/Player.cs
@@ -1,5 +1,6 @@
 ﻿
 using WarApi.Models.Interfaces;
+using System.Text.Json.Serialization;
 namespace WarApi.Models
 {
     public class Player:IPlayer
@@ -9,6 +10,7 @@ namespace WarApi.Models
         public string Apellidos { get; set; } = string.Empty;
         public string Alias { get; set; } = string.Empty;
         public string Email { get; set; } = string.Empty;
+        [JsonIgnore]
         public string Contraseña { get; set; } = string.Empty;
         public string? Foto { get; set; }
         public string Equipo { get; set; } = string.Empty;


### PR DESCRIPTION
## Summary
- hide the `Contraseña` field from JSON responses

## Testing
- `dotnet build --no-restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c0e2bd4e88321a0afe4aeb0d95094