### PR TITLE
Fix player decoding in match reports

### DIFF
--- a/Services/MatchReportService.cs
+++ b/Services/MatchReportService.cs
@@ -2,23 +2,42 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using MatchReportNamespace.Repositories;
+using WarApi.Services.Interfaces;
 
 namespace MatchReportNamespace.Services
 {
     public class MatchReportService : IMatchReportService
     {
         private readonly IMatchReportRepository _repository;
+        private readonly IPlayerService _players;
 
-        public MatchReportService(IMatchReportRepository repository)
+        public MatchReportService(IMatchReportRepository repository, IPlayerService players)
         {
             _repository = repository;
+            _players = players;
         }
 
-        public async Task<IEnumerable<MatchReport>> GetAllAsync() =>
-            await _repository.GetAllAsync();
+        private void DecodePlayers(MatchReport report)
+        {
+            var a = _players.GetById(report.PlayerAId);
+            if (a != null) report.PlayerA = a;
+            var b = _players.GetById(report.PlayerBId);
+            if (b != null) report.PlayerB = b;
+        }
 
-        public async Task<MatchReport?> GetByIdAsync(Guid id) =>
-            await _repository.GetByIdAsync(id);
+        public async Task<IEnumerable<MatchReport>> GetAllAsync()
+        {
+            var reports = (await _repository.GetAllAsync()).ToList();
+            foreach (var r in reports) DecodePlayers(r);
+            return reports;
+        }
+
+        public async Task<MatchReport?> GetByIdAsync(Guid id)
+        {
+            var report = await _repository.GetByIdAsync(id);
+            if (report != null) DecodePlayers(report);
+            return report;
+        }
 
         public async Task<MatchReport> CreateAsync(MatchReport report)
         {
@@ -30,7 +49,8 @@ namespace MatchReportNamespace.Services
 
         public async Task<List<MatchReport>> GetReportsByUser(Guid id)
         {
-            var allReports = await _repository.GetAllAsync();
+            var allReports = (await _repository.GetAllAsync()).ToList();
+            foreach (var r in allReports) DecodePlayers(r);
             return allReports.Where(x => x.PlayerAId == id || x.PlayerBId == id).ToList();
         }
 


### PR DESCRIPTION
## Summary
- decode player data when returning match reports

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686383f3b6288321b820be44402b0dfc