### PR TITLE
Add team stats and secure controllers

### DIFF
--- a/Controllers/MatchReportController.cs
+++ b/Controllers/MatchReportController.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using MatchReportNamespace.Services;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 using WarApi.Dtos;
 using WarApi.Services.Interfaces;
 using WarApi.Models;
@@ -10,6 +11,7 @@ namespace MatchReportNamespace.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]
+    [Authorize]
     public class MatchReportsController : ControllerBase
     {
         private readonly IMatchReportService _service;

--- a/Controllers/PlayerController.cs
+++ b/Controllers/PlayerController.cs
@@ -9,6 +9,7 @@ namespace WarApi.Controllers
 {
     [ApiController]
     [Route("[controller]")]
+    [Authorize]
     public class PlayerController : ControllerBase
     {
         private readonly IPlayerService _PlayerService;
@@ -21,6 +22,7 @@ namespace WarApi.Controllers
         }
 
         [HttpPost("Login")]
+        [AllowAnonymous]
         public ActionResult<LoginResponseDto> Login(string user, string pass)
         {
             var player = _PlayerService.Login(user, pass);

--- a/Controllers/PlayerStatsController.cs
+++ b/Controllers/PlayerStatsController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 using WarApi.Services.Interfaces;
 
 using WarApi.Dtos;
@@ -8,6 +9,7 @@ namespace WarApi.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]
+    [Authorize]
     public class PlayerStatsController : ControllerBase
     {
         private readonly IPlayerStatsService _statsService;

--- a/Controllers/TeamController.cs
+++ b/Controllers/TeamController.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using MatchReportNamespace.Services;
+using WarApi.Services.Interfaces;
+
+namespace WarApi.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    public class TeamController : ControllerBase
+    {
+        private readonly IPlayerService _playerService;
+        private readonly IMatchReportService _reportService;
+
+        public TeamController(IPlayerService playerService, IMatchReportService reportService)
+        {
+            _playerService = playerService;
+            _reportService = reportService;
+        }
+
+        [HttpGet("{teamName}/players")]
+        public ActionResult GetPlayers(string teamName)
+        {
+            var players = _playerService.GetAll().Where(p => p.Equipo == teamName);
+            return Ok(players);
+        }
+
+        [HttpGet("{teamName}/reports")]
+        public async Task<ActionResult> GetReports(string teamName)
+        {
+            var reports = await _reportService.GetReportsByTeam(teamName);
+            return Ok(reports);
+        }
+    }
+}

--- a/Controllers/TeamStatsController.cs
+++ b/Controllers/TeamStatsController.cs
@@ -1,0 +1,68 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using WarApi.Services.Interfaces;
+using WarApi.Dtos;
+
+namespace WarApi.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    public class TeamStatsController : ControllerBase
+    {
+        private readonly ITeamStatsService _statsService;
+
+        public TeamStatsController(ITeamStatsService statsService)
+        {
+            _statsService = statsService;
+        }
+
+        [HttpGet("{team}/total")]
+        public async Task<ActionResult<int>> GetTotal(string team)
+            => Ok(await _statsService.GetTotalGames(team));
+
+        [HttpGet("{team}/wins")]
+        public async Task<ActionResult<int>> GetWins(string team)
+            => Ok(await _statsService.GetWins(team));
+
+        [HttpGet("{team}/losses")]
+        public async Task<ActionResult<int>> GetLosses(string team)
+            => Ok(await _statsService.GetLosses(team));
+
+        [HttpGet("{team}/draws")]
+        public async Task<ActionResult<int>> GetDraws(string team)
+            => Ok(await _statsService.GetDraws(team));
+
+        [HttpGet("{team}/army/{army}/total")]
+        public async Task<ActionResult<int>> GetGamesByArmy(string team, string army)
+            => Ok(await _statsService.GetGamesByArmy(team, army));
+
+        [HttpGet("{team}/army/{army}/wins")]
+        public async Task<ActionResult<int>> GetWinsByArmy(string team, string army)
+            => Ok(await _statsService.GetWinsByArmy(team, army));
+
+        [HttpGet("{team}/map/{map}/winrate")]
+        public async Task<ActionResult<double>> GetMapWinRate(string team, string map)
+            => Ok(await _statsService.GetWinRateOnMap(team, map));
+
+        [HttpGet("{team}/deployment/{deployment}/winrate")]
+        public async Task<ActionResult<double>> GetDeploymentWinRate(string team, string deployment)
+            => Ok(await _statsService.GetWinRateByDeployment(team, deployment));
+
+        [HttpGet("{team}/primary/{mission}/winrate")]
+        public async Task<ActionResult<double>> GetPrimaryWinRate(string team, string mission)
+            => Ok(await _statsService.GetWinRateByPrimary(team, mission));
+
+        [HttpGet("{team}/best-opponent")]
+        public async Task<ActionResult<string?>> GetBestOpponent(string team)
+            => Ok(await _statsService.GetBestOpponentFaction(team));
+
+        [HttpGet("{team}/worst-opponent")]
+        public async Task<ActionResult<string?>> GetWorstOpponent(string team)
+            => Ok(await _statsService.GetWorstOpponentFaction(team));
+
+        [HttpGet("{team}/ideal-scenario/{top?}")]
+        public async Task<ActionResult<PlayerIdealScenarioDto>> GetIdealScenario(string team, int top = 1)
+            => Ok(await _statsService.GetIdealScenario(team, top));
+    }
+}

--- a/Models/AppDbContext.cs
+++ b/Models/AppDbContext.cs
@@ -10,10 +10,20 @@ namespace WarApi.Models
         public DbSet<MatchReport> MatchReports { get; set; }
         public DbSet<Player> Players { get; set; }
         public DbSet<ArmyList> ArmyLists { get; set; }
+        public DbSet<Team> Teams { get; set; }
 
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
+            modelBuilder.Entity<Team>()
+                .HasKey(t => t.Name);
+
+            modelBuilder.Entity<Player>()
+                .HasOne(p => p.Team)
+                .WithMany(t => t.Players)
+                .HasForeignKey(p => p.Equipo)
+                .HasPrincipalKey(t => t.Name);
+
             modelBuilder.Entity<MatchReport>()
                 .HasOne(m => m.PlayerA)
                 .WithMany()

--- a/Models/Player.cs
+++ b/Models/Player.cs
@@ -13,6 +13,8 @@ namespace WarApi.Models
         public string Contraseña { get; set; } = string.Empty;
         public string? Foto { get; set; }
         public string Equipo { get; set; } = string.Empty;
+
+        public Team? Team { get; set; }
         public Enums.UserRole Rol { get; set; } = Enums.UserRole.User;
 
         // Relaciones futuras

--- a/Models/Team.cs
+++ b/Models/Team.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace WarApi.Models
+{
+    public class Team
+    {
+        [Key]
+        public string Name { get; set; } = string.Empty;
+
+        public ICollection<Player> Players { get; set; } = new List<Player>();
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -70,6 +70,7 @@ builder.Services.AddScoped<IPlayerService, PlayerService>();
 builder.Services.AddScoped<IPlayerStatsService, PlayerStatsService>();
 builder.Services.AddScoped<IArmyListRepository, ArmyListRepository>();
 builder.Services.AddScoped<IArmyListService, ArmyListService>();
+builder.Services.AddScoped<ITeamStatsService, TeamStatsService>();
 builder.Services.AddSingleton<IEncryptionService, Base64EncryptionService>();
 builder.Services.AddSingleton<ITokenService, JwtTokenService>();
 builder.Services.AddSingleton<Microsoft.AspNetCore.Identity.PasswordHasher<WarApi.Models.Player>>();

--- a/Services/Interfaces/IMatchReportService.cs
+++ b/Services/Interfaces/IMatchReportService.cs
@@ -7,6 +7,7 @@ namespace MatchReportNamespace.Services
     {
         Task<IEnumerable<MatchReport>> GetAllAsync();
         Task<List<MatchReport>> GetReportsByUser(Guid id);
+        Task<List<MatchReport>> GetReportsByTeam(string teamName);
         Task<MatchReport?> GetByIdAsync(Guid id);
         Task<MatchReport> CreateAsync(MatchReport report);
         Task UpdateAsync(Guid id, MatchReport report);

--- a/Services/Interfaces/ITeamStatsService.cs
+++ b/Services/Interfaces/ITeamStatsService.cs
@@ -1,0 +1,20 @@
+using WarApi.Dtos;
+
+namespace WarApi.Services.Interfaces
+{
+    public interface ITeamStatsService
+    {
+        Task<int> GetTotalGames(string teamName);
+        Task<int> GetWins(string teamName);
+        Task<int> GetLosses(string teamName);
+        Task<int> GetDraws(string teamName);
+        Task<int> GetGamesByArmy(string teamName, string army);
+        Task<int> GetWinsByArmy(string teamName, string army);
+        Task<double> GetWinRateOnMap(string teamName, string map);
+        Task<double> GetWinRateByDeployment(string teamName, string deployment);
+        Task<double> GetWinRateByPrimary(string teamName, string primary);
+        Task<string?> GetBestOpponentFaction(string teamName);
+        Task<string?> GetWorstOpponentFaction(string teamName);
+        Task<PlayerIdealScenarioDto> GetIdealScenario(string teamName, int top);
+    }
+}

--- a/Services/MatchReportService.cs
+++ b/Services/MatchReportService.cs
@@ -54,6 +54,14 @@ namespace MatchReportNamespace.Services
             return allReports.Where(x => x.PlayerAId == id || x.PlayerBId == id).ToList();
         }
 
+        public async Task<List<MatchReport>> GetReportsByTeam(string teamName)
+        {
+            var players = _players.GetAll().Where(p => p.Equipo == teamName).Select(p => p.ID).ToHashSet();
+            var allReports = (await _repository.GetAllAsync()).ToList();
+            foreach (var r in allReports) DecodePlayers(r);
+            return allReports.Where(r => players.Contains(r.PlayerAId) || players.Contains(r.PlayerBId)).ToList();
+        }
+
         public async Task UpdateAsync(Guid id, MatchReport updatedReport)
         {
             var existing = await _repository.GetByIdAsync(id);

--- a/Services/TeamStatsService.cs
+++ b/Services/TeamStatsService.cs
@@ -1,0 +1,243 @@
+using MatchReportNamespace;
+using MatchReportNamespace.Services;
+using WarApi.Services.Interfaces;
+using WarApi.Dtos;
+
+namespace WarApi.Services
+{
+    public class TeamStatsService : ITeamStatsService
+    {
+        private readonly IMatchReportService _matchReportService;
+        private readonly IPlayerService _playerService;
+
+        public TeamStatsService(IMatchReportService matchReportService, IPlayerService playerService)
+        {
+            _matchReportService = matchReportService;
+            _playerService = playerService;
+        }
+
+        private async Task<List<MatchReport>> GetReports(string teamName)
+        {
+            return await _matchReportService.GetReportsByTeam(teamName);
+        }
+
+        private HashSet<Guid> GetPlayerIds(string teamName)
+        {
+            return _playerService.GetAll().Where(p => p.Equipo == teamName).Select(p => p.ID).ToHashSet();
+        }
+
+        private static bool IsDraw(MatchReport report)
+        {
+            return report.FinalScoreA == report.FinalScoreB;
+        }
+
+        private static bool DidTeamWin(MatchReport report, HashSet<Guid> players)
+        {
+            bool a = players.Contains(report.PlayerAId);
+            bool b = players.Contains(report.PlayerBId);
+            if (a == b) return false;
+            if (IsDraw(report)) return false;
+            return a ? report.FinalScoreA > report.FinalScoreB
+                     : report.FinalScoreB > report.FinalScoreA;
+        }
+
+        private static bool DidTeamLose(MatchReport report, HashSet<Guid> players)
+        {
+            bool a = players.Contains(report.PlayerAId);
+            bool b = players.Contains(report.PlayerBId);
+            if (a == b) return false;
+            if (IsDraw(report)) return false;
+            return a ? report.FinalScoreA < report.FinalScoreB
+                     : report.FinalScoreB < report.FinalScoreA;
+        }
+
+        private static bool TeamUsedArmy(MatchReport report, HashSet<Guid> players, string army)
+        {
+            bool a = players.Contains(report.PlayerAId);
+            bool b = players.Contains(report.PlayerBId);
+            if (a && !b)
+                return string.Equals(report.ListA, army, StringComparison.OrdinalIgnoreCase);
+            if (!a && b)
+                return string.Equals(report.ListB, army, StringComparison.OrdinalIgnoreCase);
+            return false;
+        }
+
+        private static double CalculateWinRate(int wins, int games)
+        {
+            return games == 0 ? 0 : (double)wins / games * 100.0;
+        }
+
+        public async Task<int> GetTotalGames(string teamName)
+        {
+            var reports = await GetReports(teamName);
+            return reports.Count;
+        }
+
+        public async Task<int> GetWins(string teamName)
+        {
+            var reports = await GetReports(teamName);
+            var players = GetPlayerIds(teamName);
+            return reports.Count(r => DidTeamWin(r, players));
+        }
+
+        public async Task<int> GetLosses(string teamName)
+        {
+            var reports = await GetReports(teamName);
+            var players = GetPlayerIds(teamName);
+            return reports.Count(r => DidTeamLose(r, players));
+        }
+
+        public async Task<int> GetDraws(string teamName)
+        {
+            var reports = await GetReports(teamName);
+            return reports.Count(IsDraw);
+        }
+
+        public async Task<int> GetGamesByArmy(string teamName, string army)
+        {
+            var reports = await GetReports(teamName);
+            var players = GetPlayerIds(teamName);
+            return reports.Count(r => TeamUsedArmy(r, players, army));
+        }
+
+        public async Task<int> GetWinsByArmy(string teamName, string army)
+        {
+            var reports = await GetReports(teamName);
+            var players = GetPlayerIds(teamName);
+            return reports.Where(r => TeamUsedArmy(r, players, army))
+                          .Count(r => DidTeamWin(r, players));
+        }
+
+        public async Task<double> GetWinRateOnMap(string teamName, string map)
+        {
+            var reports = (await GetReports(teamName)).Where(r => string.Equals(r.Map, map, StringComparison.OrdinalIgnoreCase)).ToList();
+            var players = GetPlayerIds(teamName);
+            int wins = reports.Count(r => DidTeamWin(r, players));
+            return CalculateWinRate(wins, reports.Count);
+        }
+
+        public async Task<double> GetWinRateByDeployment(string teamName, string deployment)
+        {
+            var reports = (await GetReports(teamName)).Where(r => string.Equals(r.Deployment, deployment, StringComparison.OrdinalIgnoreCase)).ToList();
+            var players = GetPlayerIds(teamName);
+            int wins = reports.Count(r => DidTeamWin(r, players));
+            return CalculateWinRate(wins, reports.Count);
+        }
+
+        public async Task<double> GetWinRateByPrimary(string teamName, string primary)
+        {
+            var reports = (await GetReports(teamName)).Where(r => string.Equals(r.PrimaryMission, primary, StringComparison.OrdinalIgnoreCase)).ToList();
+            var players = GetPlayerIds(teamName);
+            int wins = reports.Count(r => DidTeamWin(r, players));
+            return CalculateWinRate(wins, reports.Count);
+        }
+
+        public async Task<string?> GetBestOpponentFaction(string teamName)
+        {
+            var reports = await GetReports(teamName);
+            var players = GetPlayerIds(teamName);
+            var stats = new Dictionary<string, (int Wins, int Games)>();
+
+            foreach (var r in reports)
+            {
+                bool a = players.Contains(r.PlayerAId);
+                bool b = players.Contains(r.PlayerBId);
+                if (a && b) continue;
+                string faction = a ? r.ListB : r.ListA;
+                if (!stats.ContainsKey(faction)) stats[faction] = (0, 0);
+                var val = stats[faction];
+                if (DidTeamWin(r, players)) val.Wins++;
+                val.Games++;
+                stats[faction] = val;
+            }
+
+            if (stats.Count == 0) return null;
+            return stats.OrderByDescending(kv => CalculateWinRate(kv.Value.Wins, kv.Value.Games)).First().Key;
+        }
+
+        public async Task<string?> GetWorstOpponentFaction(string teamName)
+        {
+            var reports = await GetReports(teamName);
+            var players = GetPlayerIds(teamName);
+            var stats = new Dictionary<string, (int Wins, int Games)>();
+
+            foreach (var r in reports)
+            {
+                bool a = players.Contains(r.PlayerAId);
+                bool b = players.Contains(r.PlayerBId);
+                if (a && b) continue;
+                string faction = a ? r.ListB : r.ListA;
+                if (!stats.ContainsKey(faction)) stats[faction] = (0, 0);
+                var val = stats[faction];
+                if (DidTeamWin(r, players)) val.Wins++;
+                val.Games++;
+                stats[faction] = val;
+            }
+
+            if (stats.Count == 0) return null;
+            return stats.OrderBy(kv => CalculateWinRate(kv.Value.Wins, kv.Value.Games)).First().Key;
+        }
+
+        private static void Accumulate(Dictionary<string, (int Wins, int Games)> dict, string key, bool win)
+        {
+            if (!dict.ContainsKey(key)) dict[key] = (0, 0);
+            var val = dict[key];
+            if (win) val.Wins++;
+            val.Games++;
+            dict[key] = val;
+        }
+
+        public async Task<PlayerIdealScenarioDto> GetIdealScenario(string teamName, int top)
+        {
+            var reports = await GetReports(teamName);
+            var players = GetPlayerIds(teamName);
+            var opponents = new Dictionary<string, (int Wins, int Games)>();
+            var maps = new Dictionary<string, (int Wins, int Games)>();
+            var primaries = new Dictionary<string, (int Wins, int Games)>();
+            var secondaries = new Dictionary<string, (int Wins, int Games)>();
+
+            foreach (var r in reports)
+            {
+                bool a = players.Contains(r.PlayerAId);
+                bool b = players.Contains(r.PlayerBId);
+                if (a && b) continue;
+                bool win = DidTeamWin(r, players);
+                var sec = a ? r.SecondaryA : r.SecondaryB;
+                var opp = a ? r.ListB : r.ListA;
+
+                Accumulate(opponents, opp, win);
+                Accumulate(maps, r.Map, win);
+                Accumulate(primaries, r.PrimaryMission, win);
+                Accumulate(secondaries, sec, win);
+            }
+
+            int limit = Math.Clamp(top, 0, 12);
+
+            PlayerIdealScenarioDto result = new()
+            {
+                OpponentFactions = opponents
+                    .OrderByDescending(kv => CalculateWinRate(kv.Value.Wins, kv.Value.Games))
+                    .Take(limit)
+                    .Select(kv => kv.Key)
+                    .ToList(),
+                Maps = maps
+                    .OrderByDescending(kv => CalculateWinRate(kv.Value.Wins, kv.Value.Games))
+                    .Take(limit)
+                    .Select(kv => kv.Key)
+                    .ToList(),
+                PrimaryMissions = primaries
+                    .OrderByDescending(kv => CalculateWinRate(kv.Value.Wins, kv.Value.Games))
+                    .Take(limit)
+                    .Select(kv => kv.Key)
+                    .ToList(),
+                SecondaryMissions = secondaries
+                    .OrderByDescending(kv => CalculateWinRate(kv.Value.Wins, kv.Value.Games))
+                    .Take(limit)
+                    .Select(kv => kv.Key)
+                    .ToList()
+            };
+
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- protect all controllers with `[Authorize]` and allow anonymous login
- introduce a `Team` model and configure EF relationships
- add endpoints to list players and reports of a team
- implement team statistics service and controller
- expose new methods in match report service

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863f09b24388321868f2f692d17306e