### PR TITLE
Add unit tests for service layer

### DIFF
--- a/WarApi.Tests/Services/MatchReportServiceTests.cs
+++ b/WarApi.Tests/Services/MatchReportServiceTests.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+using MatchReportNamespace.Repositories;
+using WarApi.Services;
+using WarApi.Services.Interfaces;
+using WarApi.Models;
+
+namespace WarApi.Tests.Services
+{
+    public class MatchReportServiceTests
+    {
+        [Fact]
+        public async Task GetReportsByUser_ReturnsOnlyUserReports()
+        {
+            var userId = Guid.NewGuid();
+            var reports = new List<MatchReport>
+            {
+                new MatchReport { Id = Guid.NewGuid(), PlayerAId = userId, PlayerBId = Guid.NewGuid() },
+                new MatchReport { Id = Guid.NewGuid(), PlayerAId = Guid.NewGuid(), PlayerBId = userId },
+                new MatchReport { Id = Guid.NewGuid(), PlayerAId = Guid.NewGuid(), PlayerBId = Guid.NewGuid() }
+            };
+
+            var repoMock = new Mock<IMatchReportRepository>();
+            repoMock.Setup(r => r.GetAllAsync()).ReturnsAsync(reports);
+
+            var playerMock = new Mock<IPlayerService>();
+            playerMock.Setup(p => p.GetById(It.IsAny<Guid>())).Returns(new Player());
+
+            var service = new MatchReportService(repoMock.Object, playerMock.Object);
+            var result = await service.GetReportsByUser(userId);
+
+            Assert.Equal(2, result.Count);
+            Assert.All(result, r => Assert.True(r.PlayerAId == userId || r.PlayerBId == userId));
+        }
+    }
+}

--- a/WarApi.Tests/Services/PlayerServiceTests.cs
+++ b/WarApi.Tests/Services/PlayerServiceTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Linq;
+using Moq;
+using Xunit;
+using Microsoft.AspNetCore.Identity;
+using WarApi.Models;
+using WarApi.Repositories.Interfaces;
+using WarApi.Services;
+using WarApi.Services.Security;
+
+namespace WarApi.Tests.Services
+{
+    public class PlayerServiceTests
+    {
+        private PlayerService CreateService(out Mock<IPlayerRepository> repoMock, Player storedPlayer)
+        {
+            repoMock = new Mock<IPlayerRepository>();
+            repoMock.Setup(r => r.GetAll(true)).Returns(new[] { storedPlayer });
+            repoMock.Setup(r => r.GetById(storedPlayer.ID)).Returns(storedPlayer);
+
+            var encryption = new Base64EncryptionService();
+            var hasher = new PasswordHasher<Player>();
+            return new PlayerService(repoMock.Object, encryption, hasher);
+        }
+
+        [Fact]
+        public void Login_ReturnsPlayer_WhenPasswordMatches()
+        {
+            var player = new Player { ID = Guid.NewGuid(), Email = "test@example.com", Nombre = "John" };
+            var encryption = new Base64EncryptionService();
+            player.Nombre = encryption.Encrypt(player.Nombre);
+            var hasher = new PasswordHasher<Player>();
+            player.Contraseña = hasher.HashPassword(player, "secret");
+
+            var service = CreateService(out _, player);
+
+            var result = service.Login("test@example.com", "secret");
+
+            Assert.NotNull(result);
+            Assert.Equal("John", result!.Nombre);
+        }
+
+        [Fact]
+        public void Login_ReturnsNull_WhenPasswordDoesNotMatch()
+        {
+            var player = new Player { ID = Guid.NewGuid(), Email = "test@example.com", Nombre = "John" };
+            var encryption = new Base64EncryptionService();
+            player.Nombre = encryption.Encrypt(player.Nombre);
+            var hasher = new PasswordHasher<Player>();
+            player.Contraseña = hasher.HashPassword(player, "secret");
+
+            var service = CreateService(out _, player);
+
+            var result = service.Login("test@example.com", "wrong");
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Create_EncryptsSensitiveFields_AndHashesPassword()
+        {
+            var repoMock = new Mock<IPlayerRepository>();
+            var encryption = new Base64EncryptionService();
+            var hasher = new PasswordHasher<Player>();
+            var service = new PlayerService(repoMock.Object, encryption, hasher);
+
+            var player = new Player
+            {
+                Nombre = "John",
+                Apellidos = "Doe",
+                Alias = "JD",
+                Equipo = "TeamA",
+                Email = "test@example.com",
+                Contraseña = "secret"
+            };
+
+            service.Create(player);
+
+            repoMock.Verify(r => r.Add(It.Is<Player>(p =>
+                p.Nombre == encryption.Encrypt("John") &&
+                p.Apellidos == encryption.Encrypt("Doe") &&
+                p.Alias == encryption.Encrypt("JD") &&
+                p.Equipo == encryption.Encrypt("TeamA") &&
+                hasher.VerifyHashedPassword(p, p.Contraseña, "secret") == PasswordVerificationResult.Success
+            )), Times.Once);
+        }
+    }
+}

--- a/WarApi.Tests/Services/PlayerStatsServiceTests.cs
+++ b/WarApi.Tests/Services/PlayerStatsServiceTests.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+using MatchReportNamespace;
+using MatchReportNamespace.Services;
+using WarApi.Services;
+using WarApi.Services.Interfaces;
+using WarApi.Dtos;
+
+namespace WarApi.Tests.Services
+{
+    public class PlayerStatsServiceTests
+    {
+        private static MatchReport CreateReport(Guid playerId, bool asPlayerA, int scoreA, int scoreB, string map = "Map1")
+        {
+            return new MatchReport
+            {
+                Id = Guid.NewGuid(),
+                PlayerAId = asPlayerA ? playerId : Guid.NewGuid(),
+                PlayerBId = asPlayerA ? Guid.NewGuid() : playerId,
+                ListA = "ArmyA",
+                ListB = "ArmyB",
+                Map = map,
+                FinalScoreA = scoreA,
+                FinalScoreB = scoreB
+            };
+        }
+
+        [Fact]
+        public async Task GetTotalGames_ReturnsNumberOfReports()
+        {
+            var playerId = Guid.NewGuid();
+            var reports = new List<MatchReport>
+            {
+                CreateReport(playerId, true, 10, 5),
+                CreateReport(playerId, false, 7, 12)
+            };
+
+            var service = SetupService(playerId, reports);
+            var total = await service.GetTotalGames(playerId);
+            Assert.Equal(2, total);
+        }
+
+        [Fact]
+        public async Task GetWins_ReturnsOnlyWins()
+        {
+            var playerId = Guid.NewGuid();
+            var reports = new List<MatchReport>
+            {
+                CreateReport(playerId, true, 15, 10), // win
+                CreateReport(playerId, false, 8, 12)  // loss
+            };
+
+            var service = SetupService(playerId, reports);
+            var wins = await service.GetWins(playerId);
+            Assert.Equal(1, wins);
+        }
+
+        [Fact]
+        public async Task GetWinRateOnMap_CalculatesCorrectPercentage()
+        {
+            var playerId = Guid.NewGuid();
+            var reports = new List<MatchReport>
+            {
+                CreateReport(playerId, true, 10, 5, "Map1"),  // win
+                CreateReport(playerId, true, 8, 12, "Map1"),  // loss
+                CreateReport(playerId, false, 7, 3, "Map2")    // win but different map
+            };
+
+            var service = SetupService(playerId, reports);
+            var rate = await service.GetWinRateOnMap(playerId, "Map1");
+            Assert.Equal(50d, rate);
+        }
+
+        private static PlayerStatsService SetupService(Guid playerId, List<MatchReport> reports)
+        {
+            var mock = new Mock<IMatchReportService>();
+            mock.Setup(m => m.GetReportsByUser(playerId)).ReturnsAsync(reports);
+            return new PlayerStatsService(mock.Object);
+        }
+    }
+}

--- a/WarApi.Tests/Services/TeamStatsServiceTests.cs
+++ b/WarApi.Tests/Services/TeamStatsServiceTests.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+using MatchReportNamespace;
+using MatchReportNamespace.Services;
+using WarApi.Services;
+using WarApi.Services.Interfaces;
+using WarApi.Models;
+
+namespace WarApi.Tests.Services
+{
+    public class TeamStatsServiceTests
+    {
+        private static MatchReport CreateReport(Guid aId, Guid bId, int scoreA, int scoreB, string map = "Map1")
+        {
+            return new MatchReport
+            {
+                Id = Guid.NewGuid(),
+                PlayerAId = aId,
+                PlayerBId = bId,
+                ListA = "ArmyA",
+                ListB = "ArmyB",
+                Map = map,
+                FinalScoreA = scoreA,
+                FinalScoreB = scoreB
+            };
+        }
+
+        [Fact]
+        public async Task GetWins_CountsWinsForTeam()
+        {
+            var team = "TeamA";
+            var player1 = new Player { ID = Guid.NewGuid(), Equipo = team };
+            var player2 = new Player { ID = Guid.NewGuid(), Equipo = team };
+            var other = new Player { ID = Guid.NewGuid(), Equipo = "X" };
+
+            var reports = new List<MatchReport>
+            {
+                CreateReport(player1.ID, other.ID, 12, 8), // win
+                CreateReport(other.ID, player1.ID, 7, 15), // win
+                CreateReport(other.ID, other.ID, 10, 5)    // not team
+            };
+
+            var matchMock = new Mock<IMatchReportService>();
+            matchMock.Setup(m => m.GetReportsByTeam(team)).ReturnsAsync(reports);
+
+            var playerMock = new Mock<IPlayerService>();
+            playerMock.Setup(p => p.GetAll()).Returns(new[] { player1, player2, other });
+
+            var service = new TeamStatsService(matchMock.Object, playerMock.Object);
+            var wins = await service.GetWins(team);
+
+            Assert.Equal(2, wins);
+        }
+    }
+}

--- a/WarApi.Tests/WarApi.Tests.csproj
+++ b/WarApi.Tests/WarApi.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+    <PackageReference Include="Moq" Version="4.20.127" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\WarApi.csproj" />
+  </ItemGroup>
+</Project>

--- a/WarApi.sln
+++ b/WarApi.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.14.36203.30 d17.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WarApi", "WarApi.csproj", "{8EF5A6B5-7D9F-4B82-8AE1-0155B6EDB8BD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WarApi.Tests", "WarApi.Tests/WarApi.Tests.csproj", "{11111111-1111-1111-1111-111111111111}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{8EF5A6B5-7D9F-4B82-8AE1-0155B6EDB8BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8EF5A6B5-7D9F-4B82-8AE1-0155B6EDB8BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8EF5A6B5-7D9F-4B82-8AE1-0155B6EDB8BD}.Release|Any CPU.Build.0 = Release|Any CPU
+                {11111111-1111-1111-1111-111111111111}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {11111111-1111-1111-1111-111111111111}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {11111111-1111-1111-1111-111111111111}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {11111111-1111-1111-1111-111111111111}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- set up `WarApi.Tests` xUnit project
- add tests for `PlayerService`, `PlayerStatsService`, `TeamStatsService` and `MatchReportService`
- register the test project in solution

## Testing
- `dotnet test WarApi.Tests/WarApi.Tests.csproj -c Release` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6865551a33a08321a1605ff765be7efc