### PR TITLE
Fix match report creation inserts

### DIFF
--- a/Controllers/MatchReportController.cs
+++ b/Controllers/MatchReportController.cs
@@ -81,8 +81,6 @@ namespace MatchReportNamespace.Controllers
                 Id = Guid.NewGuid(),
                 PlayerAId = dto.PlayerAId,
                 PlayerBId = dto.PlayerBId,
-                PlayerA = playerA,
-                PlayerB = playerB,
                 ListA = dto.ListA,
                 ListB = dto.ListB,
                 ArmyA = factionA,
@@ -107,6 +105,9 @@ namespace MatchReportNamespace.Controllers
             };
 
             await _service.CreateAsync(report);
+
+            report.PlayerA = playerA;
+            report.PlayerB = playerB;
 
             return CreatedAtAction(nameof(GetById), new { id = report.Id }, report);
         }


### PR DESCRIPTION
## Summary
- prevent EF Core from attempting to insert Players when saving new match reports

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68678e6b37f88321be60836caab6b0ee