### PR TITLE
Fix update tracking error

### DIFF
--- a/Repositories/MatchReportRepository.cs
+++ b/Repositories/MatchReportRepository.cs
@@ -23,6 +23,7 @@ namespace MatchReportNamespace.Repositories
         public async Task<MatchReport?> GetByIdAsync(Guid id)
         {
             return await _context.MatchReports
+                                 .AsNoTracking()
                                  .Include(m => m.PlayerA)
                                  .Include(m => m.PlayerB)
                                  .FirstOrDefaultAsync(m => m.Id == id);


### PR DESCRIPTION
## Summary
- avoid tracking match reports when fetching by id

## Testing
- `dotnet build --no-restore` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686f53420b3483219d3ce90200b5ca4c